### PR TITLE
prepareのエミュレーションを無効にするとBEGINメソッドが正しく動作しなかったのを修正

### DIFF
--- a/SimpleDBI.php
+++ b/SimpleDBI.php
@@ -380,6 +380,7 @@ class SimpleDBI
     {
         if (count($this->trans_stack) == 0) {
             $this->pdo->beginTransaction();
+            $this->onQueryEnd('BEGIN');
             $this->is_uncommitable = false;
         }
         array_push($this->trans_stack, 'A');
@@ -398,6 +399,7 @@ class SimpleDBI
                 throw new PDOException('Cannot commit because a nested transaction was rolled back');
             } else {
                 $this->pdo->commit();
+                $this->onQueryEnd('COMMIT');
             }
         }
         array_pop($this->trans_stack);
@@ -412,6 +414,7 @@ class SimpleDBI
     {
         if (count($this->trans_stack) <= 1) {
             $this->pdo->rollBack();
+            $this->onQueryEnd('ROLLBACK');
         } else {
             $this->is_uncommitable = true;
         }


### PR DESCRIPTION
プリペアードクエリのエミュレーションを無効にし、ネイティブのprepare文を使うようにすると正常動作しないバグに気づきました。

```
$this->pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
```

コンストラクタに上記設定を追記して、MySQL 5.5.31に対してPHP 5.3.20+PDO-MySQL+libmysqlclient5.5.31でアクセスしたところ、SimpleDBI#beginがエラーで例外スローしました。

おそらくBEGIN文などはプリペアードクエリに出来ない構文なのだと思います。
