### PR TITLE
fix default value of execute()

### DIFF
--- a/src/SimpleDBIStatement.php
+++ b/src/SimpleDBIStatement.php
@@ -7,7 +7,7 @@ class SimpleDBIStatement extends PDOStatement
 {
     public $exec_time;
 
-    public function execute($params = array())
+    public function execute($params = null)
     {
         $ts = microtime(true);
         $r = parent::execute($params);

--- a/tests/SimpleDBITest.php
+++ b/tests/SimpleDBITest.php
@@ -355,4 +355,17 @@ class SimpleDBITest extends PHPUnit_Framework_TestCase
             $this->assertEquals("Invalid placeholder name: :foo_foo;bar", $e->getMessage());
         }
     }
+
+    public function test_parseSQL_03()
+    {
+        $db = SimpleDBI::conn();
+        $sql = 'SELECT 1  LIMIT :limit  OFFSET :offset';
+        $pdo = $db->getPDO();
+        $stmt = $pdo->prepare($sql);
+        $stmt->bindValue(':limit', 2, \PDO::PARAM_INT);
+        $stmt->bindValue(':offset', 3, \PDO::PARAM_INT);
+        $res = $stmt->execute();
+        $this->assertTrue($res);
+    }
+
 }


### PR DESCRIPTION
execute()を引数無しで呼ぶと、デフォルト値で空配列を渡したことになって、bindValue()がなかったことになり、SQLエラーになります。

```
SQLSTATE[HY093]: Invalid parameter number: no parameters were bound
```

```php
        $sql = "
            SELECT
                id 
            FROM items
            LIMIT :limit  OFFSET :offset
        ";

        $pdo = $simple_dbi->getPDO();
        $stmt = $pdo->prepare($sql);
        $stmt->bindValue(':limit', 10, \PDO::PARAM_INT);
        $stmt->bindValue(':offset', 10, \PDO::PARAM_INT);
        $res = $stmt->execute(); // Error occured

        $stmt->fetchAll();
```

一方 `null` を SimpleDBIStatement::execute() に明示的に渡した場合はちゃんと動きます。

`PDOStatement::execute()` のデフォルト引数が、暗黙で `null` になっているためだと思われます。

# 発生した環境
* PHP 5.6.30
* MySQL 5.6.35

おそらく他のバージョンでも発生すると思われます。