### PR TITLE
add PHP 7.0, 7.1 for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
+  - 7.1
   - hhvm
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ php:
   - hhvm
 
 before_script:
-  - composer install --no-dev
+  - composer install
   - mysql -e 'CREATE DATABASE php_simple_dbi_test'
 
 script:


### PR DESCRIPTION
* travisにPHP 7系を追加しました。
* `--no-dev` があると travisのPHP7でphpunitが入らない(むしろPHP5で--no-devなのに何でphpunitが入るのかが謎) ので外しました。
